### PR TITLE
general overhaul

### DIFF
--- a/receiver-2.asl
+++ b/receiver-2.asl
@@ -30,23 +30,33 @@ init
 {
 	vars.Unity.TryOnLoad = (Func<dynamic, bool>)(helper =>
 	{
-		var lst = helper.GetClass("mscorlib", "List`1"); // List<T>
-		var rpd = helper.GetClass("Wolfire.Receiver2", 0x200012C); // RankingProgressionData
-		var rpgm = helper.GetClass("Wolfire.Receiver2", 0x200012D); // RankingProgressionGameMode
-		var lms = helper.GetClass("Wolfire.Receiver2", 0x2000187); // LevelManagerScript
-		var gss = helper.GetClass("Wolfire.Receiver2", 0x200024D); // GameSessionStatistic
-		var rcs = helper.GetClass("Wolfire.Receiver2", 0x2000298); // ReceiverCoreScript
-		// var lah = helper.GetClass("Wolfire.Receiver2", 0x2000195); // LocalAimHandler
+		try
+		{
+			var lst = helper.GetClass("mscorlib", "List`1"); // List<T>
 
-		vars.Unity.Make<float>(lms.Static, lms["instance"], lms["load_queue"], lst["_size"]).Name = "loadQueue";
-		vars.Unity.Make<int>(rcs.Static, rcs["instance"], rcs["game_mode"], rpgm["checkpoint_rank"]).Name = "rank";
-		vars.Unity.Make<int>(rcs.Static, rcs["instance"], rcs["game_mode"], rpgm["progression_data"], rpd["regular_tapes_picked_up"]).Name = "tapesCollected";
-		// vars.Unity.Make<int>(rcs.Static, rcs["instance"], rcs["game_mode"], rpgm["progression_data"], rpd["regular_tapes_consumed"]).Name = "tapesConsumed";
-		vars.Unity.Make<float>(rcs.Static, rcs["instance"], rcs["session_data"], gss["session_time"]).Name = "time";
-		vars.Unity.Make<ulong>(rcs.Static, rcs["instance"], rcs["session_data"], gss["session_start_date_time"]).Name = "startTime";
-		// vars.Unity.Make<bool>(lah.Static, lah["player_instance"], lah["dead"]).Name = "dead";
+			var lms = helper.GetClass("Wolfire.Receiver2", 0x2000187); // LevelManagerScript
 
-		return true;
+			var rcs = helper.GetClass("Wolfire.Receiver2", 0x2000298); // ReceiverCoreScript
+			var rpgm = helper.GetClass("Wolfire.Receiver2", 0x200012D); // RankingProgressionGameMode
+			var rpd = helper.GetClass("Wolfire.Receiver2", 0x200012C); // RankingProgressionData
+			var gss = helper.GetClass("Wolfire.Receiver2", 0x200024D); // GameSessionStatistic
+			// var lah = helper.GetClass("Wolfire.Receiver2", 0x2000195); // LocalAimHandler
+
+			vars.Unity.Make<float>(lms.Static, lms["instance"], lms["load_queue"], lst["_size"]).Name = "loadQueue";
+			vars.Unity.Make<int>(rcs.Static, rcs["instance"], rcs["game_mode"], rpgm["checkpoint_rank"]).Name = "rank";
+			vars.Unity.Make<int>(rcs.Static, rcs["instance"], rcs["game_mode"], rpgm["progression_data"], rpd["regular_tapes_picked_up"]).Name = "tapesCollected";
+			// vars.Unity.Make<int>(rcs.Static, rcs["instance"], rcs["game_mode"], rpgm["progression_data"], rpd["regular_tapes_consumed"]).Name = "tapesConsumed";
+			vars.Unity.Make<float>(rcs.Static, rcs["instance"], rcs["session_data"], gss["session_time"]).Name = "time";
+			vars.Unity.Make<ulong>(rcs.Static, rcs["instance"], rcs["session_data"], gss["session_start_date_time"]).Name = "startTime";
+			// vars.Unity.Make<bool>(lah.Static, lah["player_instance"], lah["dead"]).Name = "dead";
+
+			return true;
+		}
+		catch (InvalidOperationException)
+		{
+			helper.ClearImages();
+			return false;
+		}
 	});
 
 	vars.Unity.Load(game);
@@ -64,6 +74,9 @@ update
 	current.time = vars.Unity.Watchers["time"].Current;
 	current.startTime = vars.Unity.Watchers["startTime"].Current;
 	current.tapesCollected = vars.Unity.Watchers["tapesCollected"].Current;
+
+	// if (old.tapesCollected != current.tapesCollected)
+	// 	vars.Log(old.tapesCollected + " -> " + current.tapesCollected);
 }
 
 start

--- a/receiver-2.asl
+++ b/receiver-2.asl
@@ -90,7 +90,7 @@ start
 split
 {
 	return current.rank == old.rank + 1 ||
-	       current.rank == 5 && old.tapesCollected == 2 && current.tapesCollected == 3;
+	       current.rank == 5 && old.tapesCollected == 22 && current.tapesCollected == 23;
 }
 
 reset


### PR DESCRIPTION
Alright, let's go over this.

I've created some classes to help with Unity autosplitters at [just-ero/AutoSplitHelp](https://github.com/just-ero/AutoSplitHelp). To test this autosplitter locally, you must download `mono.cs` and `mono_helpers.cs` and put it into the `Components` folder wherever you saved LiveSplit. For further distribution to other users, simply change the `LiveSplit.AutoSplitters.xml` file to look like [this](https://github.com/just-ero/AutoSplitHelp/blob/main/mono/LiveSplit.AutoSplitters-Example_PR.xml).

## What does this do?
The main idea is to stop using pointers. Unity uses Mono, which loads all classes in static memory. This means all classes can be founds via their name (or token), along with all of their fields (and their offsets). A class' static fields can then be accessed via a static address.  
`mono.cs` and `mono_helpers.cs` do this for the user, who then only has to specify which classes to get.

## Specifically what was changed?
`start {}`: Since the game handles the in-game time a bit weirdly (arbitrarily starts the timer before the first loading screen and then waits for it to finish), we first wait for the `LevelManagerScript.loadQueue` to empty, setting a flag to allow the starting of the timer when the in-game time finally begins counting up again.

`split {}`: Split either when the player's rank increases or they collect the final tape in the final level. ***This must be tested!*** I am not good, nor dedicated enough to find out if this works the way it should. This value might count up throughout the entire playthrough, meaning it does not reset when a new level is entered. If this is the case, simply store the tape count when entered level 5 and check that `value + 3` against `current.tapesCollected`.

`reset {}`: The game stores the `DateTime.Now` value of when the last run was started. When this value increases, a new run has been started.